### PR TITLE
Add UI test prompt generator

### DIFF
--- a/mcp/docs/README.md
+++ b/mcp/docs/README.md
@@ -10,7 +10,7 @@ This project is a Go-based MCP (Model Context Protocol) server designed to provi
 
 ## Tool Endpoints
 
-The following tool endpoints are available (44 total):
+The following tool endpoints are available (45 total):
 
 | Category          | Endpoint                      | Description                                                                 |
 | ----------------- | ----------------------------- | --------------------------------------------------------------------------- |
@@ -58,6 +58,11 @@ The following tool endpoints are available (44 total):
 | **Interactive**   | `/tools/run_terminal_command`     | Executes a terminal command.                                                |
 |                   | `/tools/apply_code_change`        | Applies a diff to a file.                                                   |
 |                   | `/tools/browse_with_playwright`   | Opens a URL with Playwright and captures a screenshot.                      |
+|                   | `/tools/get_latest_screenshot`    | Returns the last Playwright screenshot (path or base64).                    |
+|                   | `/tools/get_ui_metadata`          | Extracts component metadata from the captured HTML.                          |
+|                   | `/tools/get_ui_code_map`          | Maps UI components to React source files.                                   |
+|                   | `/tools/get_visual_context`       | Runs Playwright and returns screenshot, metadata and code mapping.          |
+|                   | `/tools/generate_ui_test_prompt`  | Creates a markdown prompt and screenshot for UI testing.                   |
 
 ### Complexity Analysis
 

--- a/mcp/docs/VISUAL_CONTEXT.md
+++ b/mcp/docs/VISUAL_CONTEXT.md
@@ -1,0 +1,48 @@
+# Visual Context API
+
+The MCP server can provide Figma Dev Mode style context for UI auditing.
+
+## Endpoints
+
+- `/tools/get_latest_screenshot` – return the last Playwright screenshot. Pass `{"base64": true}` to receive base64 encoded data.
+- `/tools/get_ui_metadata` – parse the previously captured HTML and return UI component metadata and text content.
+- `/tools/get_ui_code_map` – map discovered components to React source files.
+- `/tools/get_visual_context` – run Playwright for a URL and return a combined payload with screenshot, metadata and code mapping.
+- `/tools/generate_ui_test_prompt` – crawl a local URL and generate a markdown prompt with a screenshot for UI tests.
+
+## Payload Structure
+
+The `get_visual_context` tool returns a payload similar to:
+
+```makefile
+TOOL: screenshot -> img://ui-context.png
+TOOL: metadata -> [...]
+TOOL: code-connect -> [...]
+TOOL: content -> {...}
+```
+
+## Usage Example
+
+Invoke via JSON-RPC:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {"tool": "get_visual_context", "arguments": {"url": "http://localhost:3000"}}
+}
+```
+
+To generate a UI test prompt:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {"tool": "generate_ui_test_prompt", "arguments": {"url": "http://localhost:3000/dashboard"}}
+}
+```
+
+Feed the JSON result into Claude Sonnet 4 along with the screenshot path to perform visual review or generate code.

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -13,6 +13,8 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/goquery v1.8.1 // indirect
+	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.7.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/mcp/go.sum
+++ b/mcp/go.sum
@@ -1,3 +1,7 @@
+github.com/PuerkitoBio/goquery v1.8.1 h1:uQxhNlArOIdbrH1tr0UXwdVFgDcZDrZVdcpygAcwmWM=
+github.com/PuerkitoBio/goquery v1.8.1/go.mod h1:Q8ICL1kNUJ2sXGoAhPGUdYDJvgQgHzJsnnd3H7Ho5jQ=
+github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
+github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -100,8 +104,10 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
@@ -110,6 +116,7 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -126,6 +133,7 @@ golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=

--- a/mcp/internal/analyzer/ui_analyzer.go
+++ b/mcp/internal/analyzer/ui_analyzer.go
@@ -1,0 +1,204 @@
+package analyzer
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"mcp/internal/models"
+)
+
+// ParseUI parses HTML and extracts UI components and content information
+func ParseUI(html string) ([]models.UIComponent, []models.UIContent, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var comps []models.UIComponent
+	var contents []models.UIContent
+
+	doc.Find("[data-component], [role]").Each(func(i int, s *goquery.Selection) {
+		comp := models.UIComponent{
+			Name:    s.AttrOr("data-component", ""),
+			Tag:     goquery.NodeName(s),
+			ID:      s.AttrOr("id", ""),
+			Role:    s.AttrOr("role", ""),
+			Classes: strings.Fields(s.AttrOr("class", "")),
+		}
+		styleAttr, _ := s.Attr("style")
+		if styleAttr != "" {
+			parts := strings.Split(styleAttr, ";")
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					comp.Styles = append(comp.Styles, p)
+				}
+			}
+		}
+		for _, cls := range comp.Classes {
+			if strings.HasPrefix(cls, "text-") || strings.HasPrefix(cls, "bg-") || strings.HasPrefix(cls, "p-") || strings.HasPrefix(cls, "m-") || strings.HasPrefix(cls, "font-") {
+				comp.Styles = append(comp.Styles, cls)
+			}
+		}
+		comps = append(comps, comp)
+
+		c := models.UIContent{Component: comp.Name}
+		text := strings.TrimSpace(s.Text())
+		if text != "" {
+			c.Text = text
+		}
+		if alt, ok := s.Attr("alt"); ok && alt != "" {
+			c.Alt = alt
+		}
+		aria := map[string]string{}
+		for _, attr := range s.Nodes[0].Attr {
+			if strings.HasPrefix(attr.Key, "aria-") {
+				aria[attr.Key] = attr.Val
+			}
+		}
+		if len(aria) > 0 {
+			c.ARIA = aria
+		}
+		if c.Text != "" || c.Alt != "" || len(c.ARIA) > 0 {
+			if c.Component == "" {
+				if comp.ID != "" {
+					c.Component = comp.ID
+				} else if comp.Role != "" {
+					c.Component = comp.Role
+				} else {
+					c.Component = comp.Tag
+				}
+			}
+			contents = append(contents, c)
+		}
+	})
+
+	return comps, contents, nil
+}
+
+// MapComponentsToSource attempts to map components to React files in the repo
+func MapComponentsToSource(root string, comps []models.UIComponent) ([]models.CodeMap, error) {
+	var result []models.CodeMap
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() || !(strings.HasSuffix(path, ".tsx") || strings.HasSuffix(path, ".jsx")) {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		content := string(data)
+		for _, comp := range comps {
+			key := comp.Name
+			if key == "" {
+				key = comp.ID
+			}
+			if key == "" {
+				continue
+			}
+			if strings.Contains(content, key) {
+				snippet := extractSnippet(content, key)
+				result = append(result, models.CodeMap{Component: key, File: path, Snippet: snippet})
+			}
+		}
+		return nil
+	})
+	return result, err
+}
+
+func extractSnippet(fileContent, token string) string {
+	lines := strings.Split(fileContent, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, token) {
+			trimmed := strings.TrimSpace(line)
+			if len(trimmed) > 120 {
+				return trimmed[:120]
+			}
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// BuildUIPrompt assembles the final payload
+func BuildUIPrompt(screenshot string, comps []models.UIComponent, code []models.CodeMap, content []models.UIContent) models.UIPromptPayload {
+	return models.UIPromptPayload{
+		Screenshot: models.UIScreenshot{Path: screenshot},
+		Metadata:   comps,
+		CodeMap:    code,
+		Content:    content,
+	}
+}
+
+// ExtractTestElements parses HTML and returns UI elements useful for testing
+func ExtractTestElements(html string) ([]models.UITestElement, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return nil, err
+	}
+
+	var elements []models.UITestElement
+	selectors := []string{"input", "button", "form", "[role=dialog]", "[role=tab]", "[data-testid]"}
+	doc.Find(strings.Join(selectors, ",")).Each(func(i int, s *goquery.Selection) {
+		el := models.UITestElement{
+			Type:       goquery.NodeName(s),
+			Text:       strings.TrimSpace(s.Text()),
+			ID:         s.AttrOr("id", ""),
+			Name:       s.AttrOr("name", ""),
+			DataTestID: s.AttrOr("data-testid", ""),
+			Classes:    strings.Fields(s.AttrOr("class", "")),
+		}
+		aria := map[string]string{}
+		for _, attr := range s.Nodes[0].Attr {
+			if strings.HasPrefix(attr.Key, "aria-") {
+				aria[attr.Key] = attr.Val
+			}
+		}
+		if len(aria) > 0 {
+			el.ARIA = aria
+		}
+		elements = append(elements, el)
+	})
+	return elements, nil
+}
+
+// BuildUITestMarkdown writes a markdown prompt describing the page elements
+func BuildUITestMarkdown(url string, elems []models.UITestElement, screenshot string) (string, error) {
+	ts := time.Now().Unix()
+	file := filepath.Join(os.TempDir(), fmt.Sprintf("ui_prompt_%d.md", ts))
+	f, err := os.Create(file)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "Page: %s\n", url)
+	fmt.Fprintf(f, "Screenshot: %s\n\n", screenshot)
+	fmt.Fprintln(f, "Components:")
+	for _, e := range elems {
+		meta := []string{}
+		if e.ID != "" {
+			meta = append(meta, fmt.Sprintf("id: %s", e.ID))
+		}
+		if e.Name != "" {
+			meta = append(meta, fmt.Sprintf("name: %s", e.Name))
+		}
+		if e.DataTestID != "" {
+			meta = append(meta, fmt.Sprintf("data-testid: %s", e.DataTestID))
+		}
+		line := fmt.Sprintf("- %s: \"%s\"", strings.Title(e.Type), e.Text)
+		if len(meta) > 0 {
+			line += " (" + strings.Join(meta, ", ") + ")"
+		}
+		fmt.Fprintln(f, line)
+	}
+	return file, nil
+}

--- a/mcp/internal/jsonrpc/mcp_tools_dispatcher.go
+++ b/mcp/internal/jsonrpc/mcp_tools_dispatcher.go
@@ -381,6 +381,63 @@ func (s *JSONRPCServer) handleListTools(ctx context.Context, params json.RawMess
 				"required": []string{"url"},
 			},
 		},
+		{
+			Name:        "get_latest_screenshot",
+			Description: "Return the most recent Playwright screenshot",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"base64": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Return base64 encoded data",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_ui_metadata",
+			Description: "Extract component metadata from the last HTML capture",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "get_ui_code_map",
+			Description: "Map captured components to React source files",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "get_visual_context",
+			Description: "Run Playwright and assemble screenshot, metadata and code mapping",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "URL to visit",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
+		{
+			Name:        "generate_ui_test_prompt",
+			Description: "Generate a UI test prompt from a local URL",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "URL to visit",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
 
 		// New Tools (6 additional to reach 34)
 		{
@@ -553,6 +610,16 @@ func (s *JSONRPCServer) handleCallTool(ctx context.Context, params json.RawMessa
 		return s.callApplyCodeChange(ctx, toolCall.Arguments)
 	case "browse_with_playwright":
 		return s.callBrowseWithPlaywright(ctx, toolCall.Arguments)
+	case "get_latest_screenshot":
+		return s.callGetLatestScreenshot(ctx, toolCall.Arguments)
+	case "get_ui_metadata":
+		return s.callGetUIMetadata(ctx)
+	case "get_ui_code_map":
+		return s.callGetUICodeMap(ctx)
+	case "get_visual_context":
+		return s.callGetVisualContext(ctx, toolCall.Arguments)
+	case "generate_ui_test_prompt":
+		return s.callGenerateUITestPrompt(ctx, toolCall.Arguments)
 
 	// New Tools
 	case "analyze_performance":

--- a/mcp/internal/jsonrpc/mcp_ui_handlers.go
+++ b/mcp/internal/jsonrpc/mcp_ui_handlers.go
@@ -1,0 +1,99 @@
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"mcp/internal/models"
+)
+
+// UI context tool handlers
+
+func (s *JSONRPCServer) callGetLatestScreenshot(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	toBase64, _ := args["base64"].(bool)
+	shot, err := s.bridge.GetLatestScreenshot(toBase64)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	data, _ := json.Marshal(shot)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(data))}},
+	}, nil
+}
+
+func (s *JSONRPCServer) callGetUIMetadata(ctx context.Context) (interface{}, error) {
+	comps, content, err := s.bridge.GetUIMetadata()
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	payload := struct {
+		Components []models.UIComponent `json:"components"`
+		Content    []models.UIContent   `json:"content"`
+	}{comps, content}
+	b, _ := json.Marshal(payload)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(b))}},
+	}, nil
+}
+
+func (s *JSONRPCServer) callGetUICodeMap(ctx context.Context) (interface{}, error) {
+	comps, _, err := s.bridge.GetUIMetadata()
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	mapping, err := s.bridge.GetUICodeMap(comps)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	data, _ := json.Marshal(mapping)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(data))}},
+	}, nil
+}
+
+func (s *JSONRPCServer) callGetVisualContext(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	url, ok := args["url"].(string)
+	if !ok {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": "url parameter required"}},
+		}, nil
+	}
+	payload, err := s.bridge.GetVisualContext(url)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	b, _ := json.Marshal(payload)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(b))}},
+	}, nil
+}
+
+func (s *JSONRPCServer) callGenerateUITestPrompt(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	url, ok := args["url"].(string)
+	if !ok {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": "url parameter required"}},
+		}, nil
+	}
+	result, err := s.bridge.GenerateUITestPrompt(url)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	b, _ := json.Marshal(result)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(b))}},
+	}, nil
+}

--- a/mcp/internal/models/mcp_models.go
+++ b/mcp/internal/models/mcp_models.go
@@ -314,6 +314,62 @@ type PlaywrightResult struct {
 	Screenshot string `json:"screenshot"`
 }
 
+// UIComponent represents a single UI element extracted from the DOM
+type UIComponent struct {
+	Name    string   `json:"name,omitempty"`
+	Tag     string   `json:"tag,omitempty"`
+	ID      string   `json:"id,omitempty"`
+	Role    string   `json:"role,omitempty"`
+	Classes []string `json:"classes,omitempty"`
+	Styles  []string `json:"styles,omitempty"`
+}
+
+// UIContent holds visible text and accessibility information for a component
+type UIContent struct {
+	Component string            `json:"component"`
+	Text      string            `json:"text,omitempty"`
+	Alt       string            `json:"alt,omitempty"`
+	ARIA      map[string]string `json:"aria,omitempty"`
+}
+
+// CodeMap maps a UI component to a source file snippet
+type CodeMap struct {
+	Component string `json:"component"`
+	File      string `json:"file"`
+	Snippet   string `json:"snippet"`
+}
+
+// UIScreenshot represents the screenshot location or encoded data
+type UIScreenshot struct {
+	Path   string `json:"path,omitempty"`
+	Base64 string `json:"base64,omitempty"`
+}
+
+// UIPromptPayload aggregates visual context for LLM consumption
+type UIPromptPayload struct {
+	Screenshot UIScreenshot  `json:"screenshot"`
+	Metadata   []UIComponent `json:"metadata"`
+	CodeMap    []CodeMap     `json:"code_connect"`
+	Content    []UIContent   `json:"content"`
+}
+
+// UITestElement represents a UI element relevant for testing
+type UITestElement struct {
+	Type       string            `json:"type"`
+	Text       string            `json:"text,omitempty"`
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	DataTestID string            `json:"dataTestId,omitempty"`
+	Classes    []string          `json:"classes,omitempty"`
+	ARIA       map[string]string `json:"aria,omitempty"`
+}
+
+// UITestPromptResult is returned by generate_ui_test_prompt
+type UITestPromptResult struct {
+	PromptPath     string `json:"prompt"`
+	ScreenshotPath string `json:"screenshot"`
+}
+
 // MCP Protocol Types
 
 // MCPRequest represents a generic MCP request

--- a/mcp/internal/server/bridge.go
+++ b/mcp/internal/server/bridge.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,8 +30,10 @@ import (
 // It allows other Go components or extensions to interact with the server's
 // functionality directly, bypassing the HTTP layer.
 type Bridge struct {
-	DB          *sql.DB
-	BackendPath string
+	DB             *sql.DB
+	BackendPath    string
+	LastHTML       string
+	LastScreenshot string
 	// Add other common dependencies here if needed by multiple tools
 }
 
@@ -38,8 +41,10 @@ type Bridge struct {
 // It takes the necessary dependencies that the underlying tool logic requires.
 func NewBridge(db *sql.DB, backendPath string) *Bridge {
 	return &Bridge{
-		DB:          db,
-		BackendPath: backendPath,
+		DB:             db,
+		BackendPath:    backendPath,
+		LastHTML:       "",
+		LastScreenshot: "",
 	}
 }
 
@@ -636,7 +641,72 @@ func (b *Bridge) BrowseWithPlaywright(url string) (models.PlaywrightResult, erro
 	if !config.Flags.AllowTerminal {
 		return models.PlaywrightResult{}, errors.New("terminal commands are disabled")
 	}
-	return analyzer.BrowseWithPlaywright(url)
+	result, err := analyzer.BrowseWithPlaywright(url)
+	if err == nil {
+		b.LastHTML = result.HTML
+		b.LastScreenshot = result.Screenshot
+	}
+	return result, err
+}
+
+// GetLatestScreenshot returns the last Playwright screenshot
+func (b *Bridge) GetLatestScreenshot(toBase64 bool) (models.UIScreenshot, error) {
+	if b.LastScreenshot == "" {
+		return models.UIScreenshot{}, errors.New("no screenshot available")
+	}
+	if !toBase64 {
+		return models.UIScreenshot{Path: b.LastScreenshot}, nil
+	}
+	data, err := os.ReadFile(b.LastScreenshot)
+	if err != nil {
+		return models.UIScreenshot{}, err
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+	return models.UIScreenshot{Base64: encoded, Path: b.LastScreenshot}, nil
+}
+
+// GetUIMetadata parses the last fetched HTML and returns component metadata and content
+func (b *Bridge) GetUIMetadata() ([]models.UIComponent, []models.UIContent, error) {
+	if b.LastHTML == "" {
+		return nil, nil, errors.New("no HTML captured")
+	}
+	return analyzer.ParseUI(b.LastHTML)
+}
+
+// GetUICodeMap maps components to source files
+func (b *Bridge) GetUICodeMap(comps []models.UIComponent) ([]models.CodeMap, error) {
+	return analyzer.MapComponentsToSource(b.BackendPath, comps)
+}
+
+// GetVisualContext runs Playwright and builds the prompt payload
+func (b *Bridge) GetVisualContext(url string) (models.UIPromptPayload, error) {
+	result, err := b.BrowseWithPlaywright(url)
+	if err != nil {
+		return models.UIPromptPayload{}, err
+	}
+	comps, content, err := analyzer.ParseUI(result.HTML)
+	if err != nil {
+		return models.UIPromptPayload{}, err
+	}
+	codeMap, _ := analyzer.MapComponentsToSource(b.BackendPath, comps)
+	return analyzer.BuildUIPrompt(result.Screenshot, comps, codeMap, content), nil
+}
+
+// GenerateUITestPrompt crawls a local URL and writes a markdown prompt
+func (b *Bridge) GenerateUITestPrompt(url string) (models.UITestPromptResult, error) {
+	result, err := b.BrowseWithPlaywright(url)
+	if err != nil {
+		return models.UITestPromptResult{}, err
+	}
+	elems, err := analyzer.ExtractTestElements(result.HTML)
+	if err != nil {
+		return models.UITestPromptResult{}, err
+	}
+	promptPath, err := analyzer.BuildUITestMarkdown(url, elems, result.Screenshot)
+	if err != nil {
+		return models.UITestPromptResult{}, err
+	}
+	return models.UITestPromptResult{PromptPath: promptPath, ScreenshotPath: result.Screenshot}, nil
 }
 
 // GetDatabaseStats returns database statistics


### PR DESCRIPTION
## Summary
- expose a new `/tools/generate_ui_test_prompt` endpoint
- support extracting testable UI elements
- produce markdown prompts with screenshots for AI testing
- document the new tool and usage

## Testing
- `./codex/status.sh` *(fails: pg_isready missing)*

------
https://chatgpt.com/codex/tasks/task_e_685da2266704832286721d39db4a0e4d