### PR TITLE
Add Playwright actions tool

### DIFF
--- a/mcp/docs/README.md
+++ b/mcp/docs/README.md
@@ -62,6 +62,7 @@ The following tool endpoints are available (44 total):
 |                   | `/tools/get_ui_metadata`          | Extracts component metadata from the captured HTML.                          |
 |                   | `/tools/get_ui_code_map`          | Maps UI components to React source files.                                   |
 |                   | `/tools/get_visual_context`       | Runs Playwright and returns screenshot, metadata and code mapping.          |
+|                   | `/tools/generate_ui_test_prompt_with_actions` | Runs Playwright actions and returns visual context. |
 
 ### Complexity Analysis
 

--- a/mcp/docs/VISUAL_CONTEXT.md
+++ b/mcp/docs/VISUAL_CONTEXT.md
@@ -8,6 +8,7 @@ The MCP server can provide Figma Dev Mode style context for UI auditing.
 - `/tools/get_ui_metadata` – parse the previously captured HTML and return UI component metadata and text content.
 - `/tools/get_ui_code_map` – map discovered components to React source files.
 - `/tools/get_visual_context` – run Playwright for a URL and return a combined payload with screenshot, metadata and code mapping.
+- `/tools/generate_ui_test_prompt_with_actions` – open a page, execute JSON-defined actions, and return visual context including final HTML and URL.
 
 ## Payload Structure
 
@@ -34,3 +35,39 @@ Invoke via JSON-RPC:
 ```
 
 Feed the JSON result into Claude Sonnet 4 along with the screenshot path to perform visual review or generate code.
+
+### With Action Sequence
+
+Input format for `generate_ui_test_prompt_with_actions`:
+
+```json
+{
+  "url": "http://localhost:3000/login",
+  "actions": [
+    {"action": "type", "selector": "#email", "text": "user@example.com"},
+    {"action": "type", "selector": "#password", "text": "secret"},
+    {"action": "click", "selector": "button[type=submit]"},
+    {"action": "waitForSelector", "selector": "#dashboard"}
+  ]
+}
+```
+
+JSON-RPC call example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "tool": "generate_ui_test_prompt_with_actions",
+    "arguments": {"url": "http://localhost:3000/login", "actions": [...]} 
+  }
+}
+```
+
+CLI invocation:
+
+```bash
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"tool":"generate_ui_test_prompt_with_actions","arguments":{...}}}' | ./mcp-server
+```

--- a/mcp/internal/analyzer/code_analyzer.go
+++ b/mcp/internal/analyzer/code_analyzer.go
@@ -731,6 +731,85 @@ func BrowseWithPlaywright(url string) (models.PlaywrightResult, error) {
 	return models.PlaywrightResult{URL: url, HTML: html, Screenshot: screenshotPath}, nil
 }
 
+// BrowseWithPlaywrightActions opens a URL and executes a series of UI actions
+func BrowseWithPlaywrightActions(url string, actions []models.UIAction) (models.PlaywrightResult, error) {
+	pw, err := playwright.Run()
+	if err != nil {
+		return models.PlaywrightResult{}, err
+	}
+	browser, err := pw.Chromium.Launch()
+	if err != nil {
+		pw.Stop()
+		return models.PlaywrightResult{}, err
+	}
+	page, err := browser.NewPage()
+	if err != nil {
+		browser.Close()
+		pw.Stop()
+		return models.PlaywrightResult{}, err
+	}
+	if _, err := page.Goto(url); err != nil {
+		page.Close()
+		browser.Close()
+		pw.Stop()
+		return models.PlaywrightResult{}, err
+	}
+	// Execute actions sequentially
+	for _, a := range actions {
+		switch strings.ToLower(a.Action) {
+		case "type":
+			if a.Selector == "" {
+				return models.PlaywrightResult{}, fmt.Errorf("type action missing selector")
+			}
+			if err := page.Type(a.Selector, a.Text); err != nil {
+				return models.PlaywrightResult{}, err
+			}
+		case "click":
+			if a.Selector == "" {
+				return models.PlaywrightResult{}, fmt.Errorf("click action missing selector")
+			}
+			if _, err := page.Click(a.Selector); err != nil {
+				return models.PlaywrightResult{}, err
+			}
+		case "waitforselector":
+			if a.Selector == "" {
+				return models.PlaywrightResult{}, fmt.Errorf("waitForSelector action missing selector")
+			}
+			opts := playwright.PageWaitForSelectorOptions{}
+			if a.Timeout > 0 {
+				opts.Timeout = playwright.Float(float64(a.Timeout))
+			}
+			if _, err := page.WaitForSelector(a.Selector, opts); err != nil {
+				return models.PlaywrightResult{}, err
+			}
+		case "navigate":
+			if a.URL == "" {
+				return models.PlaywrightResult{}, fmt.Errorf("navigate action missing url")
+			}
+			if _, err := page.Goto(a.URL); err != nil {
+				return models.PlaywrightResult{}, err
+			}
+		default:
+			return models.PlaywrightResult{}, fmt.Errorf("unknown action: %s", a.Action)
+		}
+	}
+	html, _ := page.Content()
+	htmlPath := filepath.Join(os.TempDir(), fmt.Sprintf("playwright_%d.html", time.Now().UnixNano()))
+	_ = os.WriteFile(htmlPath, []byte(html), 0644)
+	screenshotPath := filepath.Join(os.TempDir(), fmt.Sprintf("playwright_%d.png", time.Now().UnixNano()))
+	if _, err := page.Screenshot(playwright.PageScreenshotOptions{Path: playwright.String(screenshotPath), FullPage: playwright.Bool(true)}); err != nil {
+		page.Close()
+		browser.Close()
+		pw.Stop()
+		return models.PlaywrightResult{}, err
+	}
+	currentURL := page.URL()
+	page.Close()
+	browser.Close()
+	pw.Stop()
+	return models.PlaywrightResult{URL: currentURL, HTML: html, Screenshot: screenshotPath, HTMLPath: htmlPath}, nil
+}
+
 // ParseApiSchema analyzes API schema from Go files
 func ParseApiSchema(apiDir string) (interface{}, error) {
 	var schema struct {

--- a/mcp/internal/analyzer/ui_analyzer.go
+++ b/mcp/internal/analyzer/ui_analyzer.go
@@ -127,11 +127,13 @@ func extractSnippet(fileContent, token string) string {
 }
 
 // BuildUIPrompt assembles the final payload
-func BuildUIPrompt(screenshot string, comps []models.UIComponent, code []models.CodeMap, content []models.UIContent) models.UIPromptPayload {
+func BuildUIPrompt(screenshot string, comps []models.UIComponent, code []models.CodeMap, content []models.UIContent, html string, url string) models.UIPromptPayload {
 	return models.UIPromptPayload{
 		Screenshot: models.UIScreenshot{Path: screenshot},
 		Metadata:   comps,
 		CodeMap:    code,
 		Content:    content,
+		HTML:       html,
+		URL:        url,
 	}
 }

--- a/mcp/internal/jsonrpc/mcp_tools_dispatcher.go
+++ b/mcp/internal/jsonrpc/mcp_tools_dispatcher.go
@@ -424,6 +424,35 @@ func (s *JSONRPCServer) handleListTools(ctx context.Context, params json.RawMess
 				"required": []string{"url"},
 			},
 		},
+		{
+			Name:        "generate_ui_test_prompt_with_actions",
+			Description: "Run Playwright with scripted actions and return visual context",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "Initial URL",
+					},
+					"actions": map[string]interface{}{
+						"type":        "array",
+						"description": "List of UI actions",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"action":   map[string]interface{}{"type": "string"},
+								"selector": map[string]interface{}{"type": "string"},
+								"text":     map[string]interface{}{"type": "string"},
+								"url":      map[string]interface{}{"type": "string"},
+								"timeout":  map[string]interface{}{"type": "integer"},
+							},
+							"required": []string{"action"},
+						},
+					},
+				},
+				"required": []string{"url", "actions"},
+			},
+		},
 
 		// New Tools (6 additional to reach 34)
 		{
@@ -604,6 +633,8 @@ func (s *JSONRPCServer) handleCallTool(ctx context.Context, params json.RawMessa
 		return s.callGetUICodeMap(ctx)
 	case "get_visual_context":
 		return s.callGetVisualContext(ctx, toolCall.Arguments)
+	case "generate_ui_test_prompt_with_actions":
+		return s.callGenerateUITestPromptWithActions(ctx, toolCall.Arguments)
 
 	// New Tools
 	case "analyze_performance":

--- a/mcp/internal/jsonrpc/mcp_ui_handlers.go
+++ b/mcp/internal/jsonrpc/mcp_ui_handlers.go
@@ -78,3 +78,40 @@ func (s *JSONRPCServer) callGetVisualContext(ctx context.Context, args map[strin
 		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(b))}},
 	}, nil
 }
+
+func (s *JSONRPCServer) callGenerateUITestPromptWithActions(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	url, ok := args["url"].(string)
+	if !ok {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": "url parameter required"}},
+		}, nil
+	}
+	rawActions, ok := args["actions"]
+	if !ok {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": "actions parameter required"}},
+		}, nil
+	}
+	data, err := json.Marshal(rawActions)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	var actions []models.UIAction
+	if err := json.Unmarshal(data, &actions); err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	payload, err := s.bridge.GenerateUITestPromptWithActions(url, actions)
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("Error: %v", err)}},
+		}, nil
+	}
+	b, _ := json.Marshal(payload)
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": fmt.Sprintf("```json\n%s\n```", string(b))}},
+	}, nil
+}

--- a/mcp/internal/models/mcp_models.go
+++ b/mcp/internal/models/mcp_models.go
@@ -312,6 +312,7 @@ type PlaywrightResult struct {
 	URL        string `json:"url"`
 	HTML       string `json:"html"`
 	Screenshot string `json:"screenshot"`
+	HTMLPath   string `json:"html_path,omitempty"`
 }
 
 // UIComponent represents a single UI element extracted from the DOM
@@ -339,6 +340,15 @@ type CodeMap struct {
 	Snippet   string `json:"snippet"`
 }
 
+// UIAction describes an automated browser action for Playwright
+type UIAction struct {
+	Action   string `json:"action"`
+	Selector string `json:"selector,omitempty"`
+	Text     string `json:"text,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Timeout  int    `json:"timeout,omitempty"`
+}
+
 // UIScreenshot represents the screenshot location or encoded data
 type UIScreenshot struct {
 	Path   string `json:"path,omitempty"`
@@ -351,6 +361,8 @@ type UIPromptPayload struct {
 	Metadata   []UIComponent `json:"metadata"`
 	CodeMap    []CodeMap     `json:"code_connect"`
 	Content    []UIContent   `json:"content"`
+	HTML       string        `json:"html,omitempty"`
+	URL        string        `json:"url,omitempty"`
 }
 
 // MCP Protocol Types

--- a/mcp/internal/server/bridge.go
+++ b/mcp/internal/server/bridge.go
@@ -689,7 +689,26 @@ func (b *Bridge) GetVisualContext(url string) (models.UIPromptPayload, error) {
 		return models.UIPromptPayload{}, err
 	}
 	codeMap, _ := analyzer.MapComponentsToSource(b.BackendPath, comps)
-	return analyzer.BuildUIPrompt(result.Screenshot, comps, codeMap, content), nil
+	return analyzer.BuildUIPrompt(result.Screenshot, comps, codeMap, content, result.HTML, result.URL), nil
+}
+
+// GenerateUITestPromptWithActions runs Playwright with scripted actions
+func (b *Bridge) GenerateUITestPromptWithActions(url string, actions []models.UIAction) (models.UIPromptPayload, error) {
+	if !config.Flags.AllowTerminal {
+		return models.UIPromptPayload{}, errors.New("terminal commands are disabled")
+	}
+	result, err := analyzer.BrowseWithPlaywrightActions(url, actions)
+	if err != nil {
+		return models.UIPromptPayload{}, err
+	}
+	b.LastHTML = result.HTML
+	b.LastScreenshot = result.Screenshot
+	comps, content, err := analyzer.ParseUI(result.HTML)
+	if err != nil {
+		return models.UIPromptPayload{}, err
+	}
+	codeMap, _ := analyzer.MapComponentsToSource(b.BackendPath, comps)
+	return analyzer.BuildUIPrompt(result.Screenshot, comps, codeMap, content, result.HTML, result.URL), nil
 }
 
 // GetDatabaseStats returns database statistics


### PR DESCRIPTION
## Summary
- add `UIAction` model and extend `UIPromptPayload`
- implement Playwright automation flow support
- expose new `generate_ui_test_prompt_with_actions` RPC endpoint
- document new tool and usage

## Testing
- `./codex/status.sh` *(fails: pg_isready not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5dc554c8322a5b555f617d5b580