### PR TITLE
Fix openapi endpoint count in MCP

### DIFF
--- a/mcp/internal/jsonrpc/mcp_database_handlers.go
+++ b/mcp/internal/jsonrpc/mcp_database_handlers.go
@@ -59,9 +59,10 @@ func (s *JSONRPCServer) callGetAPISchema() (interface{}, error) {
 		"content": []map[string]interface{}{
 			{
 				"type": "text",
-				"text": fmt.Sprintf("API Schema Analysis:\n%+v", schema),
+				"text": fmt.Sprintf("API schema retrieved successfully. Found %d endpoints.", len(schema.Endpoints)),
 			},
 		},
+		"schema": schema,
 	}, nil
 }
 
@@ -237,24 +238,24 @@ func (s *JSONRPCServer) callAnalyzeComplexity() (interface{}, error) {
 
 // callGetLintDiagnostics implements the get_lint_diagnostics tool
 func (s *JSONRPCServer) callGetLintDiagnostics() (interface{}, error) {
-        diags, err := s.bridge.GetLintDiagnostics()
-        if err != nil {
-                return map[string]interface{}{
-                        "content": []map[string]interface{}{
-                                {
-                                        "type": "text",
-                                        "text": fmt.Sprintf("Error getting lint diagnostics: %v", err),
-                                },
-                        },
-                }, nil
-        }
+	diags, err := s.bridge.GetLintDiagnostics()
+	if err != nil {
+		return map[string]interface{}{
+			"content": []map[string]interface{}{
+				{
+					"type": "text",
+					"text": fmt.Sprintf("Error getting lint diagnostics: %v", err),
+				},
+			},
+		}, nil
+	}
 
-        return map[string]interface{}{
-                "content": []map[string]interface{}{
-                        {
-                                "type": "text",
-                                "text": fmt.Sprintf("Lint diagnostics with %s: %d issues, %d compile errors", diags.Linter, len(diags.Issues), len(diags.CompileErrors)),
-                        },
-                },
-        }, nil
+	return map[string]interface{}{
+		"content": []map[string]interface{}{
+			{
+				"type": "text",
+				"text": fmt.Sprintf("Lint diagnostics with %s: %d issues, %d compile errors", diags.Linter, len(diags.Issues), len(diags.CompileErrors)),
+			},
+		},
+	}, nil
 }


### PR DESCRIPTION
## Summary
- improve `get_backend_openapi_schema` to parse OpenAPI files and gin routes
- return endpoint count alongside schema data

## Testing
- `./.codex/check-backend.sh` *(fails: TestHealthCheckHandler_HandleHealthCheck, TestCampaignOrchestratorUnified, TestCampaignWorkerService, TestDNSCampaignService, TestDomainGenerationService, TestHTTPKeywordCampaignService, TestPhase2cPerformanceSuite)*

------
https://chatgpt.com/codex/tasks/task_e_68606afdc6e08322801e73370a2f8730